### PR TITLE
Assume a more restrictive role for the "images" provider

### DIFF
--- a/terraform/bucket_roles.tf
+++ b/terraform/bucket_roles.tf
@@ -8,7 +8,7 @@ module "production_bucket_access" {
 
   account_ids = [data.aws_caller_identity.current.account_id]
   entity_name = aws_iam_user.user.name
-  role_name   = "ThirdPartyBucketRead-production-${aws_iam_user.user.name}"
+  role_name   = "ThirdPartyBucketRead-${aws_iam_user.user.name}"
   role_tags = merge(var.tags,
     {
       "GitHub_Secret_Name"             = "TEST_ROLE_TO_ASSUME",
@@ -26,7 +26,7 @@ module "staging_bucket_access" {
 
   account_ids = [data.aws_caller_identity.current.account_id]
   entity_name = aws_iam_user.user.name
-  role_name   = "ThirdPartyBucketRead-staging-${aws_iam_user.user.name}"
+  role_name   = "ThirdPartyBucketRead-${aws_iam_user.user.name}"
   role_tags   = var.tags
   s3_bucket   = var.staging_bucket_name
   s3_objects  = var.staging_objects

--- a/terraform/bucket_roles.tf
+++ b/terraform/bucket_roles.tf
@@ -3,7 +3,7 @@
 module "production_bucket_access" {
   source = "github.com/cisagov/s3-read-role-tf-module"
   providers = {
-    aws = aws.images
+    aws = aws.images_production
   }
 
   account_ids = [data.aws_caller_identity.current.account_id]
@@ -21,7 +21,7 @@ module "production_bucket_access" {
 module "staging_bucket_access" {
   source = "github.com/cisagov/s3-read-role-tf-module"
   providers = {
-    aws = aws.images
+    aws = aws.images_staging
   }
 
   account_ids = [data.aws_caller_identity.current.account_id]

--- a/terraform/bucket_roles.tf
+++ b/terraform/bucket_roles.tf
@@ -1,0 +1,33 @@
+# Create the roles that allow read-only access to the particular S3
+# objects that are required by this Ansible role
+module "production_bucket_access" {
+  source = "github.com/cisagov/s3-read-role-tf-module"
+  providers = {
+    aws = aws.images
+  }
+
+  account_ids = [data.aws_caller_identity.current.account_id]
+  entity_name = aws_iam_user.user.name
+  role_name   = "ThirdPartyBucketRead-production-${aws_iam_user.user.name}"
+  role_tags = merge(var.tags,
+    {
+      "GitHub_Secret_Name"             = "TEST_ROLE_TO_ASSUME",
+      "GitHub_Secret_Terraform_Lookup" = "arn"
+    }
+  )
+  s3_bucket  = var.production_bucket_name
+  s3_objects = var.production_objects
+}
+module "staging_bucket_access" {
+  source = "github.com/cisagov/s3-read-role-tf-module"
+  providers = {
+    aws = aws.images
+  }
+
+  account_ids = [data.aws_caller_identity.current.account_id]
+  entity_name = aws_iam_user.user.name
+  role_name   = "ThirdPartyBucketRead-staging-${aws_iam_user.user.name}"
+  role_tags   = var.tags
+  s3_bucket   = var.staging_bucket_name
+  s3_objects  = var.staging_objects
+}

--- a/terraform/iam_user.tf
+++ b/terraform/iam_user.tf
@@ -11,29 +11,8 @@ resource "aws_iam_access_key" "key" {
   user = aws_iam_user.user.name
 }
 
-# Create the role that allows read-only access to the particular S3
-# objects that are required by this Ansible role
-module "bucket_access" {
-  source = "github.com/cisagov/s3-read-role-tf-module"
-  providers = {
-    aws = aws.images
-  }
-
-  account_ids = [data.aws_caller_identity.current.account_id]
-  entity_name = aws_iam_user.user.name
-  role_name   = "ThirdPartyBucketRead-${aws_iam_user.user.name}"
-  role_tags = merge(var.tags,
-    {
-      "GitHub_Secret_Name"             = "TEST_ROLE_TO_ASSUME",
-      "GitHub_Secret_Terraform_Lookup" = "arn"
-    }
-  )
-  s3_bucket  = var.bucket_name
-  s3_objects = var.objects
-}
-
 # Ensure that the test user is allowed to assume the bucket read-only
-# role
+# roles
 data "aws_iam_policy_document" "assume_bucket_role" {
   statement {
     effect = "Allow"
@@ -44,7 +23,8 @@ data "aws_iam_policy_document" "assume_bucket_role" {
     ]
 
     resources = [
-      module.bucket_access.role.arn,
+      module.production_bucket_access.role.arn,
+      module.staging_bucket_access.role.arn,
     ]
   }
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,11 +1,21 @@
-output "policy" {
-  value       = module.bucket_access.policy
-  description = "The IAM policy that can read the specified objects from the specified S3 bucket."
+output "production_policy" {
+  value       = module.production_bucket_access.policy
+  description = "The IAM policy that can read the specified objects from the specified S3 production bucket."
 }
 
-output "role" {
-  value       = module.bucket_access.role
-  description = "The IAM role that can read the specified objects from the specified S3 bucket."
+output "production_role" {
+  value       = module.production_bucket_access.role
+  description = "The IAM role that can read the specified objects from the specified S3 production bucket."
+}
+
+output "staging_policy" {
+  value       = module.staging_bucket_access.policy
+  description = "The IAM policy that can read the specified objects from the specified S3 staging bucket."
+}
+
+output "staging_role" {
+  value       = module.staging_bucket_access.role
+  description = "The IAM role that can read the specified objects from the specified S3 staging bucket."
 }
 
 output "user" {
@@ -16,4 +26,5 @@ output "user" {
 output "user_access_key" {
   value       = aws_iam_access_key.key
   description = "The access key for the IAM user being created to test the cisagov/ansible-cobalt-strike Ansible role."
+  sensitive   = true
 }

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -6,13 +6,24 @@ provider "aws" {
   region = var.aws_region
 }
 
-# The provider used to create roles that can read certificates from an
-# S3 bucket
+# The provider used to create roles that can read certificates from a
+# production S3 bucket
 provider "aws" {
-  alias  = "images"
+  alias  = "images_production"
   region = var.aws_region
   assume_role {
-    role_arn     = data.terraform_remote_state.images.outputs.provisionthirdpartybucketreadroles_role.arn
+    role_arn     = data.terraform_remote_state.images_production.outputs.provisionthirdpartybucketreadroles_role.arn
+    session_name = local.caller_user_name
+  }
+}
+
+# The provider used to create roles that can read certificates from a
+# staging S3 bucket
+provider "aws" {
+  alias  = "images_staging"
+  region = var.aws_region
+  assume_role {
+    role_arn     = data.terraform_remote_state.images_staging.outputs.provisionthirdpartybucketreadroles_role.arn
     session_name = local.caller_user_name
   }
 }

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -12,7 +12,7 @@ provider "aws" {
   alias  = "images"
   region = var.aws_region
   assume_role {
-    role_arn     = data.terraform_remote_state.images.outputs.provisionaccount_role.arn
+    role_arn     = data.terraform_remote_state.images.outputs.provisionthirdpartybucketreadroles_role.arn
     session_name = local.caller_user_name
   }
 }

--- a/terraform/remote_states.tf
+++ b/terraform/remote_states.tf
@@ -4,7 +4,7 @@
 # data for this configuration.
 # ------------------------------------------------------------------------------
 
-data "terraform_remote_state" "images" {
+data "terraform_remote_state" "images_production" {
   backend = "s3"
 
   config = {
@@ -17,6 +17,21 @@ data "terraform_remote_state" "images" {
   }
 
   workspace = "production"
+}
+
+data "terraform_remote_state" "images_staging" {
+  backend = "s3"
+
+  config = {
+    encrypt        = true
+    bucket         = "cisa-cool-terraform-state"
+    dynamodb_table = "terraform-state-lock"
+    profile        = "cool-terraform-readstate"
+    region         = "us-east-1"
+    key            = "cool-accounts/images.tfstate"
+  }
+
+  workspace = "staging"
 }
 
 data "terraform_remote_state" "users" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -10,15 +10,27 @@ variable "aws_region" {
   default     = "us-east-1"
 }
 
-variable "bucket_name" {
+variable "production_bucket_name" {
   type        = string
-  description = "The name of the S3 bucket where the Cobalt Strike tarball and license live."
+  description = "The name of the S3 bucket where the production Cobalt Strike tarball and license live."
   default     = "cisa-cool-third-party-production"
 }
 
-variable "objects" {
+variable "production_objects" {
   type        = list(string)
-  description = "The Cobalt Strike tarball and license objects inside the bucket."
+  description = "The Cobalt Strike tarball and license objects inside the production bucket."
+  default     = ["cobaltstrike.tgz", "cobaltstrike.license"]
+}
+
+variable "staging_bucket_name" {
+  type        = string
+  description = "The name of the S3 bucket where the staging Cobalt Strike tarball and license live."
+  default     = "cisa-cool-third-party-staging"
+}
+
+variable "staging_objects" {
+  type        = list(string)
+  description = "The Cobalt Strike tarball and license objects inside the staging bucket."
   default     = ["cobaltstrike.tgz", "cobaltstrike.license"]
 }
 


### PR DESCRIPTION
## 🗣 Description

This pull request changes the Terraform test user code to assume a more restrictive role for the "images" provider.  Thanks to @dav3r for pointing this out.

This pull request also gives the test user permission to read from the _staging_ S3 3rd party bucket.

Finally, this pull request splits `iam_user.tf` into `iam_user.tf` and `bucket_roles.tf`, as the single file was becoming too unwieldy.

## 💭 Motivation and Context

Assuming a more restrictive role increases security.  Least privilege!

When running locally, the user can specify the staging bucket via the Ansible role parameter if desired.  Both the production and staging S3 read-only roles will be reused in [cisagov/teamserver-packer](https://github.com/cisagov/teamserver-packer).

## 🧪 Testing

All pre-commit hooks and molecule tests pass.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
