### PR TITLE
Install the boto3 package as part of installing Cobalt Strike

### DIFF
--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -1,13 +1,6 @@
 ---
-# boto3 is installed anywhere we would be applying this Ansible role,
-# and this role also requires a Java installation
-- name: Install boto3
+# This role requires a Java installation
+- name: Install OpenJDK
   hosts: all
   roles:
     - openjdk
-    - pip
-  tasks:
-    - name: Install boto3
-      pip:
-        name:
-          - boto3

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,5 +1,3 @@
 ---
 - src: https://github.com/cisagov/ansible-role-openjdk
   name: openjdk
-- src: https://github.com/cisagov/ansible-role-pip
-  name: pip

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,6 +23,11 @@
 
 - name: Install and license Cobalt Strike
   block:
+    # The aws_s3 Ansible module requires boto3 to be installed
+    - name: Install boto3
+      package:
+        name: "{{ boto3_package_names }}"
+
     - name: Grab Cobalt Strike tarball and license from S3
       aws_s3:
         bucket: "{{ bucket_name }}"

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -4,3 +4,7 @@
 # The packages to install for pexpect
 pexpect_package_names:
   - python3-pexpect
+
+# The packages to install for boto3
+boto3_package_names:
+  - python3-boto3

--- a/vars/Debian_9.yml
+++ b/vars/Debian_9.yml
@@ -4,3 +4,7 @@
 # The packages to install for pexpect
 pexpect_package_names:
   - python-pexpect
+
+# The packages to install for boto3
+boto3_package_names:
+  - python-boto3


### PR DESCRIPTION
## 🗣 Description

This pull request adds the boto3 package as part of the Cobalt Strike installation and removes its installation from the prepare playbook.

## 💭 Motivation and Context

boto3 is a hard requirement for pulling the Cobalt Strike tarball and license from S3, and under python3 it is missing from the Debian Buster AMI that i am starting from in [cisagov/teamserver-packer](https://github.com/cisagov/teamserver-packer).

## 🧪 Testing

All pre-commit hooks and molecule tests pass.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
