### PR TITLE
Install Cobalt Strike 4 by default

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,6 @@
 # license files are stored
 bucket_name: cisa-cool-third-party-production
 # The name of the AWS S3 object that is the Cobalt Strike tarball
-tarball_object_name: cobaltstrike.tgz
+tarball_object_name: cobaltstrike_4.tgz
 # The name of the AWS S3 object that is the Cobalt Strike license
 license_object_name: cobaltstrike.license

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -1,7 +1,22 @@
 ---
-# boto3 is installed anywhere we would be applying this Ansible role,
+# The Debian images we are using require a cache update before they
+# can install anything.
+- name: Group hosts by OS distribution
+  hosts: all
+  tasks:
+    - name: Group hosts by OS distribution
+      group_by:
+        key: os_{{ ansible_os_family }}
+- name: Update apt cache (Debian)
+  hosts: os_Debian:os_Kali_GNU_Linux
+  tasks:
+    - name: Update apt cache
+      apt:
+        update_cache: yes
+
+# boto3 is installed anywhere we would be applying this Ansible role
 # and this role also requires a Java installation
-- name: Install boto3
+- name: Install Java and boto3
   hosts: all
   roles:
     - openjdk

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -19,7 +19,11 @@ variable "production_bucket_name" {
 variable "production_objects" {
   type        = list(string)
   description = "The Cobalt Strike tarball and license objects inside the production bucket."
-  default     = ["cobaltstrike.tgz", "cobaltstrike.license"]
+  default = [
+    "cobaltstrike_3.tgz",
+    "cobaltstrike_4.tgz",
+    "cobaltstrike.license"
+  ]
 }
 
 variable "staging_bucket_name" {
@@ -31,7 +35,11 @@ variable "staging_bucket_name" {
 variable "staging_objects" {
   type        = list(string)
   description = "The Cobalt Strike tarball and license objects inside the staging bucket."
-  default     = ["cobaltstrike.tgz", "cobaltstrike.license"]
+  default = [
+    "cobaltstrike_3.tgz",
+    "cobaltstrike_4.tgz",
+    "cobaltstrike.license"
+  ]
 }
 
 variable "tags" {

--- a/vars/Debian_9.13.yml
+++ b/vars/Debian_9.13.yml
@@ -1,0 +1,1 @@
+Debian_9.yml


### PR DESCRIPTION
## 🗣 Description

This pull request makes the following changes:
* It adds an apt cache update for Debian-based OSs in the prepare playbook
* It adds support for Debian 9.13
* It modifies the Ansible role to install Cobalt Strike 4 by default

## 💭 Motivation and Context

* The apt cache update is necessary since our Debian-based base images cannot install packages without it.
* Debian 9 must be supported until CyHy is ported to Python3.
* The Kali VMs that the PCA folks and other assessors use now comes with only Cobalt Strike 4.  In order for the Cobalt Strike UI and teamserver to communicate they must both be at the same version. 

## 🧪 Testing

All pre-commit hooks and molecule tests pass.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
