### PR TITLE
Comment out the code to upgrade Cobalt Strike

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -63,6 +63,9 @@
         path: /tmp/{{ tarball_object_name }}
         state: absent
 
+    # TODO: Uncomment these two tasks when that becomes possible.  See
+    # #31 for more details:
+    # https://github.com/cisagov/ansible-role-cobalt-strike/issues/31
     #
     # Upgrade Cobalt Strike
     #

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -68,16 +68,16 @@
     #
     # The expect Ansible module requires pexpect.
     #
-    - name: Install pexpect
-      ansible.builtin.package:
-        name: "{{ pexpect_package_names }}"
-    - name: Upgrade Cobalt Strike
-      ansible.builtin.expect:
-        chdir: /opt/cobaltstrike
-        command: sh ./update
-        timeout: 300
-        responses:
-          continue: "yes"
-      async: 300
-      poll: 30
+    # - name: Install pexpect
+    #   ansible.builtin.package:
+    #     name: "{{ pexpect_package_names }}"
+    # - name: Upgrade Cobalt Strike
+    #   ansible.builtin.expect:
+    #     chdir: /opt/cobaltstrike
+    #     command: sh ./update
+    #     timeout: 300
+    #     responses:
+    #       continue: "yes"
+    #   async: 300
+    #   poll: 30
   when: not cobaltstrike_directory.stat.exists


### PR DESCRIPTION
## 🗣 Description ##

This pull request comments out the Ansible code that upgrades Cobalt Strike.

## 💭 Motivation and context ##

The latest Cobalt Strike (4.3) has a bug that affects PCAs; therefore we cannot upgrade beyond version 4.2 at the moment.  I have also replaced our Cobalt Strike tarballs in S3 with a new one that contains version 4.2.

Another issue is that our license was recently renewed.  The update process creates a new `cobaltstrike.auth` file with an updated license end date.  Without updating Cobalt Strike we will not have the updated `cobaltstrike.auth` file.  The new tarball I have put in S3 contains a `cobaltstrike.auth` file with the license end date already updated.

Once a version of Cobalt Strike with a fix for the bug is released we can go back to upgrading Cobalt Strike.

## 🧪 Testing ##

All `pre-commit` hooks pass.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] _All_ future TODOs are captured in issues, which are referenced in code comments.
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
