### PR TITLE
Uncomment the code to upgrade Cobalt Strike

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -63,24 +63,21 @@
         path: /tmp/{{ tarball_object_name }}
         state: absent
 
-    # TODO: Uncomment these two tasks when that becomes possible.  See
-    # #31 for more details:
-    # https://github.com/cisagov/ansible-role-cobalt-strike/issues/31
     #
     # Upgrade Cobalt Strike
     #
     # The expect Ansible module requires pexpect.
     #
-    # - name: Install pexpect
-    #   ansible.builtin.package:
-    #     name: "{{ pexpect_package_names }}"
-    # - name: Upgrade Cobalt Strike
-    #   ansible.builtin.expect:
-    #     chdir: /opt/cobaltstrike
-    #     command: sh ./update
-    #     timeout: 300
-    #     responses:
-    #       continue: "yes"
-    #   async: 300
-    #   poll: 30
+    - name: Install pexpect
+      ansible.builtin.package:
+        name: "{{ pexpect_package_names }}"
+    - name: Upgrade Cobalt Strike
+      ansible.builtin.expect:
+        chdir: /opt/cobaltstrike
+        command: sh ./update
+        timeout: 300
+        responses:
+          continue: "yes"
+      async: 300
+      poll: 30
   when: not cobaltstrike_directory.stat.exists


### PR DESCRIPTION
## 🗣 Description ##

This pull request uncomments the code that upgrades Cobalt Strike to the latest version.  This reverts PR #30, which was a temporary measure to work around a broken Cobalt Strike release.

## 💭 Motivation and context ##

@teal-e verified that version 4.3 of Cobalt Strike does not have the bug that made version 4.2 unusable, so we can again upgrade to the latest version in this Ansible role.

This commit resolves #31.

## 🧪 Testing ##

All `pre-commit` hooks and `molecule` tests pass.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
