### PR TITLE
Modify code to download a fresh tarball from the CS website

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ Requires that a Java implementation be installed.
 |----------|-------------|---------|----------|
 | bucket_name | The name of the AWS S3 bucket where the Cobalt Strike tarball and license files are stored. | `cisa-cool-third-party-production` | No |
 | license_object_name | The name of the AWS S3 object that is the Cobalt Strike license. | `cobaltstrike.license` | No |
-| tarball_object_name | The name of the AWS S3 object that is the Cobalt Strike tarball. | `cobaltstrike.tgz` | No |
 
 ## Dependencies ##
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,10 +1,6 @@
 ---
-# defaults file for ansible-role-cobalt-strike
-
-# The name of the AWS S3 bucket where the Cobalt Strike tarball and
-# license files are stored
+# The name of the AWS S3 bucket where the Cobalt Strike license file
+# is stored
 bucket_name: cisa-cool-third-party-production
-# The name of the AWS S3 object that is the Cobalt Strike tarball
-tarball_object_name: cobaltstrike_4.tgz
 # The name of the AWS S3 object that is the Cobalt Strike license
 license_object_name: cobaltstrike.license

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,8 +42,6 @@
     #     method: POST
     #     return_content: yes
     #     url: https://www.cobaltstrike.com/download
-    #     # grep --fixed-strings 'href="/downloads/' |
-    #     # cut --delimiter='/' --fields=3
     #   become: no
     #   delegate_to: localhost
     #   register: download_token

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,49 +18,85 @@
 
 - name: Install and license Cobalt Strike
   block:
-    - name: Grab Cobalt Strike tarball and license from S3
+    - name: Grab Cobalt Strike license from S3
       amazon.aws.aws_s3:
         bucket: "{{ bucket_name }}"
-        object: "{{ item }}"
-        dest: "/tmp/{{ item }}"
+        object: "{{ license_object_name }}"
+        dest: "/tmp/cobaltstrike.license"
         mode: get
       become: no
       delegate_to: localhost
-      loop:
-        - "{{ tarball_object_name }}"
-        - "{{ license_object_name }}"
 
-    - name: Copy the Cobalt Strike tarball
-      ansible.builtin.copy:
-        src: /tmp/{{ tarball_object_name }}
-        dest: /tmp/{{ tarball_object_name }}
-        mode: 0644
+    - name: Install curl
+      ansible.builtin.package:
+        name:
+          - curl
+
+    # I'd prefer to use ansible.builtin.uri here, but the following
+    # code doesn't work with the Cobalt Strike site:
+    # - name: Get download token from Cobalt Strike website
+    #   ansible.builtin.uri:
+    #     body: dlkey={{ cobaltstrike_license }}
+    #     body_format: "form-urlencoded"
+    #     dest: /tmp/html.html
+    #     method: POST
+    #     return_content: yes
+    #     url: https://www.cobaltstrike.com/download
+    #     # grep --fixed-strings 'href="/downloads/' |
+    #     # cut --delimiter='/' --fields=3
+    #   become: no
+    #   delegate_to: localhost
+    #   register: download_token
+    #   vars:
+    #     cobaltstrike_license: >-
+    #       "{{ lookup('file', '/tmp/cobaltstrike.license') | trim }}"
+    #
+    # This is the reason for the skip_ansible_lint tag below.
+    - name: Get download token from Cobalt Strike website
+      ansible.builtin.command: >-
+        curl https://www.cobaltstrike.com/download
+        --data "dlkey={{ cobaltstrike_license }}" --output /tmp/token.html
+      become: no
+      delegate_to: localhost
+      tags:
+        - skip_ansible_lint
+      vars:
+        cobaltstrike_license: >-
+          "{{ lookup('file', '/tmp/cobaltstrike.license') }}"
+
+    - name: Extract the download token and download the Cobalt Strike tarball
+      ansible.builtin.get_url:
+        url: "https://www.cobaltstrike.com/downloads/{{ lookup('file', '/tmp/token.html') | regex_search('href=\"/downloads/([0-9a-f]+)/cobaltstrike-dist.zip\"', '\\1') | first }}/cobaltstrike-dist.tgz"
+        dest: /tmp
 
     - name: Copy the Cobalt Strike license
       ansible.builtin.copy:
-        src: /tmp/{{ license_object_name }}
+        src: /tmp/cobaltstrike.license
         dest: /root/.cobaltstrike.license
         mode: 0400
 
-    - name: Delete local copies of Cobalt Strike tarball and license
+    - name: >
+        Delete local copies of Cobalt Strike tarball and license, as well as
+        the download token
       ansible.builtin.file:
         path: "/tmp/{{ item }}"
         state: absent
       become: no
       delegate_to: localhost
       loop:
-        - "{{ tarball_object_name }}"
-        - "{{ license_object_name }}"
+        - cobaltstrike-dist.tgz
+        - cobaltstrike.license
+        - token.html
 
     - name: Extract the Cobalt Strike tarball
       ansible.builtin.unarchive:
-        src: /tmp/{{ tarball_object_name }}
+        src: /tmp/cobaltstrike-dist.tgz
         dest: /opt
         remote_src: yes
 
     - name: Delete remote copy of Cobalt Strike tarball
       ansible.builtin.file:
-        path: /tmp/{{ tarball_object_name }}
+        path: /tmp/cobaltstrike-dist.tgz
         state: absent
 
     #

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -32,7 +32,7 @@ variable "staging_bucket_name" {
 
 variable "staging_objects" {
   type        = list(string)
-  description = "The Cobalt Strike tarball and license object(s) inside the staging bucket."
+  description = "The Cobalt Strike license object(s) inside the staging bucket."
   default = [
     "cobaltstrike.license"
   ]

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -18,10 +18,8 @@ variable "production_bucket_name" {
 
 variable "production_objects" {
   type        = list(string)
-  description = "The Cobalt Strike tarball and license objects inside the production bucket."
+  description = "The Cobalt Strike license object(s) inside the production bucket."
   default = [
-    "cobaltstrike_3.tgz",
-    "cobaltstrike_4.tgz",
     "cobaltstrike.license"
   ]
 }
@@ -34,10 +32,8 @@ variable "staging_bucket_name" {
 
 variable "staging_objects" {
   type        = list(string)
-  description = "The Cobalt Strike tarball and license objects inside the staging bucket."
+  description = "The Cobalt Strike tarball and license object(s) inside the staging bucket."
   default = [
-    "cobaltstrike_3.tgz",
-    "cobaltstrike_4.tgz",
     "cobaltstrike.license"
   ]
 }


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the code to download a fresh tarball from the CS website, instead of pulling a potentially outdated tarball from our third-party S3 bucket.

## 💭 Motivation and context ##

Previously we were using a supposedly blessed tarball that we kept in an S3 bucket, but I have since learned that there is nothing special about those tarballs.

There is also an issue where the tarballs we were using were too outdated to upgrade themselves, as described in
cisagov/ansible-role-cobalt-strike#43.  Hence this change resolves cisagov/ansible-role-cobalt-strike#43.

## 🧪 Testing ##

All `pre-commit` hooks and `molecule` tests pass.  I also verified locally (by running `molecule --verbose converge` and examining the output) that Cobalt Strike upgrades successfully with these changes.

## ✅ Checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.
