### PR TITLE
Change the hostname from which the installer is downloaded

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -52,7 +52,7 @@
     # This is the reason for the skip_ansible_lint tag below.
     - name: Get download token from Cobalt Strike website
       ansible.builtin.command: >-
-        curl https://www.cobaltstrike.com/download
+        curl https://download.cobaltstrike.com/download
         --data "dlkey={{ cobaltstrike_license }}" --output /tmp/token.html
       become: no
       delegate_to: localhost
@@ -64,7 +64,7 @@
 
     - name: Extract the download token and download the Cobalt Strike tarball
       ansible.builtin.get_url:
-        url: "https://www.cobaltstrike.com/downloads/{{ lookup('file', '/tmp/token.html') | regex_search('href=\"/downloads/([0-9a-f]+)/cobaltstrike-dist.zip\"', '\\1') | first }}/cobaltstrike-dist.tgz"
+        url: "https://download.cobaltstrike.com/downloads/{{ lookup('file', '/tmp/token.html') | regex_search('href=\"/downloads/([0-9a-f]+)/cobaltstrike-dist.zip\"', '\\1') | first }}/cobaltstrike-dist.tgz"
         dest: /tmp
 
     - name: Copy the Cobalt Strike license


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the hostname in the Cobalt Strike download URLs.  This Ansible role started failing last night because the old URLs now return [301 error codes](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/301).

## 💭 Motivation and context ##

Resolves #45.

## 🧪 Testing ##

All `pre-commit` hooks and `molecule` tests pass.

## ✅ Checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.
