### PR TITLE
Remove installation of boto3 and make the OpenJDK dependency explicit

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,7 @@
 # These owners will be the default owners for everything in the
 # repo. Unless a later match takes precedence, these owners will be
 # requested for review when someone opens a pull request.
-* @dav3r @jsf9k
+* @dav3r @jsf9k @mcdonnnj
 
 # These folks own any files in the .github directory at the root of
 # the repository and any of its subdirectories.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ in the repository's settings.
 
 ## Requirements ##
 
-Requires that a Java implementation be installed.
+None.
 
 ## Role Variables ##
 
@@ -69,7 +69,7 @@ Requires that a Java implementation be installed.
 
 ## Dependencies ##
 
-None.
+- [cisagov/ansible-role-openjdk](https://github.com/cisagov/ansible-role-openjdk)
 
 ## Example Playbook ##
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -29,4 +29,7 @@ galaxy_info:
         - focal
   role_name: cobalt_strike
 
-dependencies: []
+dependencies:
+  # CobaltStrike requires Java to run
+  - src: https://github.com/cisagov/ansible-role-openjdk
+    name: openjdk

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -30,6 +30,6 @@ galaxy_info:
   role_name: cobalt_strike
 
 dependencies:
-  # CobaltStrike requires Java to run
+  # Cobalt Strike requires Java to run
   - src: https://github.com/cisagov/ansible-role-openjdk
     name: openjdk

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -4,16 +4,3 @@
 
 - name: Import python playbook
   ansible.builtin.import_playbook: python.yml
-
-# boto3 is installed anywhere we would be applying this Ansible role
-# and this role also requires a Java installation
-- name: Install Java and boto3
-  hosts: all
-  roles:
-    - openjdk
-    - pip
-  tasks:
-    - name: Install boto3
-      ansible.builtin.pip:
-        name:
-          - boto3


### PR DESCRIPTION
## 🗣 Description ##

This pull request:
- Removes the installation of the Python `boto3` package
- Makes the OpenJDK dependency explicit

## 💭 Motivation and context ##

- `boto3` is only needed on the Ansible controller for this Ansible role.
- I previously just mentioned in the `README` that a Java implementation is required for Cobalt Strike, since I didn't want to force users to use OpenJDK.  At this point I think it makes sense to make the dependency explicit for consistency of builds.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.