### PR TITLE
Add a test to verify Cobalt Strike version and licensing

### DIFF
--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -42,7 +42,7 @@ def test_files2(host, f):
 def test_version_and_license(host):
     """Verify that Cobalt Strike is licensed and is an expected version."""
     cmd = host.run("cd /opt/cobaltstrike && ./teamserver")
-    regex = r"^\[\*\] Team Server Version: (?P<version>\d+\.\d+\.\d+) \((?P<date>\d{8})\) (?P<licensed>.*)$"
+    regex = r"^\[\*\] Team Server Version: (?P<version>\d+\.\d+\.\d+) \((?P<year>\d{4})(?P<month>\d{2})(?P<day>\d{2})\) (?P<licensed>.*)$"
     # Note that re.MULTILINE is critical here, since the output of the
     # command spans several lines
     print(repr(strip_ansi(cmd.stdout)))
@@ -54,10 +54,9 @@ def test_version_and_license(host):
         semver.VersionInfo.parse(version) >= min_expected_version
     ), f"Cobalt Strike version is expected to be greater than or equal to {min_expected_version}."
 
-    date = match.group("date")
-    year = int(date[0:4])
-    month = int(date[4:6])
-    day = int(date[6:8])
+    year = int(match.group("year"))
+    month = int(match.group("month"))
+    day = int(match.group("day"))
     assert (
         datetime.date(year, month, day) >= min_expected_release_date
     ), f"Cobalt Strike release date is expected to be no earlier than {min_expected_release_date}."

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -1,11 +1,19 @@
 """Module containing the tests for the default scenario."""
 
 # Standard Python Libraries
+import datetime
 import os
+import re
 
 # Third-Party Libraries
 import pytest
+import semver
+from strip_ansi import strip_ansi
 import testinfra.utils.ansible_runner
+
+min_expected_version = semver.VersionInfo.parse("4.7.2")
+min_expected_release_date = datetime.date(2022, 10, 17)
+expected_licensed_value = "Licensed"
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ["MOLECULE_INVENTORY_FILE"]
@@ -29,3 +37,30 @@ def test_files(host, f):
 def test_files2(host, f):
     """Test that the expected files and directories were deleted."""
     assert not host.file(f).exists
+
+
+def test_version_and_license(host):
+    """Verify that Cobalt Strike is licensed and is an expected version."""
+    cmd = host.run("cd /opt/cobaltstrike && ./teamserver")
+    regex = r"^\[\*\] Team Server Version: (?P<version>\d+\.\d+\.\d+) \((?P<date>\d{8})\) (?P<licensed>.*)$"
+    # Note that re.MULTILINE is critical here, since the output of the
+    # command spans several lines
+    print(repr(strip_ansi(cmd.stdout)))
+    match = re.search(regex, strip_ansi(cmd.stdout), re.MULTILINE)
+    assert match is not None, "Regex does not match Cobalt Strike output."
+
+    version = match.group("version")
+    assert (
+        semver.VersionInfo.parse(version) >= min_expected_version
+    ), f"Cobalt Strike version is expected to be greater than or equal to {min_expected_version}."
+
+    date = match.group("date")
+    year = int(date[0:4])
+    month = int(date[4:6])
+    day = int(date[6:8])
+    assert (
+        datetime.date(year, month, day) >= min_expected_release_date
+    ), f"Cobalt Strike release date is expected to be no earlier than {min_expected_release_date}."
+
+    licensed = match.group("licensed")
+    assert licensed == expected_licensed_value, "Cobalt Strike is not licensed."

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -11,4 +11,6 @@ flake8
 molecule[docker]
 pre-commit
 pytest-testinfra
+semver
+strip-ansi
 yamllint


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds a Molecule test to verify that:
- The version of Cobalt Strike after updating is later than the minimum expected version
- Cobalt Strike is licensed

## 💭 Motivation and context ##

When Cobalt Strike has an out-of-band update due to a security issue, the modus operandi has been to build a new AMI and manually verify that the version of Cobalt Strike installed on it is sufficiently new to contain the security fix.  With this change one can simply update the expected values in the Molecule test code and re-run the Molecule tests; if they pass then a newly-built AMI will contain the security fix.  This change therefore introduces an efficiency that will save developer time.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.