### PR TITLE
Fix broken test

### DIFF
--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -40,7 +40,9 @@ def test_files2(host, f):
 def test_version_and_license(host):
     """Verify that Cobalt Strike is licensed and is an expected version."""
     cmd = host.run("cd /opt/cobaltstrike && ./teamserver")
-    regex = r"^\[\*\] Team Server Version: (?P<version>(\d+\.)?\d+) (?P<licensed>.*)$"
+    regex = (
+        r"^\[\*\] Team Server Version: (?P<version>(\d+)(\.\d+){1,2}) (?P<licensed>.*)$"
+    )
     # Note that re.MULTILINE is critical here, since the output of the
     # command spans several lines
     match = re.search(regex, strip_ansi(cmd.stdout), re.MULTILINE)

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -45,7 +45,6 @@ def test_version_and_license(host):
     regex = r"^\[\*\] Team Server Version: (?P<version>\d+\.\d+\.\d+) \((?P<year>\d{4})(?P<month>\d{2})(?P<day>\d{2})\) (?P<licensed>.*)$"
     # Note that re.MULTILINE is critical here, since the output of the
     # command spans several lines
-    print(repr(strip_ansi(cmd.stdout)))
     match = re.search(regex, strip_ansi(cmd.stdout), re.MULTILINE)
     assert match is not None, "Regex does not match Cobalt Strike output."
 

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -10,7 +10,7 @@ import semver
 from strip_ansi import strip_ansi
 import testinfra.utils.ansible_runner
 
-min_expected_version = semver.VersionInfo.parse("4.7.2")
+min_expected_version = semver.VersionInfo.parse("4.8.0")
 expected_licensed_value = "Licensed"
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -47,8 +47,19 @@ def test_version_and_license(host):
     assert match is not None, "Regex does not match Cobalt Strike output."
 
     version = match.group("version")
+    try:
+        actual_version = semver.VersionInfo.parse(version)
+    except ValueError:
+        # CobaltStrike sometimes breaks semver by not including the
+        # patch version when it should be zero.
+        try:
+            actual_version = semver.VersionInfo.parse(f"{version}.0")
+        except ValueError:
+            assert (
+                False
+            ), f"Unable to parse {version} or {version}.0 as a valid semantic version."
     assert (
-        semver.VersionInfo.parse(version) >= min_expected_version
+        actual_version >= min_expected_version
     ), f"Cobalt Strike version is expected to be greater than or equal to {min_expected_version}."
 
     licensed = match.group("licensed")

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -1,7 +1,6 @@
 """Module containing the tests for the default scenario."""
 
 # Standard Python Libraries
-import datetime
 import os
 import re
 
@@ -12,7 +11,6 @@ from strip_ansi import strip_ansi
 import testinfra.utils.ansible_runner
 
 min_expected_version = semver.VersionInfo.parse("4.7.2")
-min_expected_release_date = datetime.date(2022, 10, 17)
 expected_licensed_value = "Licensed"
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
@@ -42,7 +40,7 @@ def test_files2(host, f):
 def test_version_and_license(host):
     """Verify that Cobalt Strike is licensed and is an expected version."""
     cmd = host.run("cd /opt/cobaltstrike && ./teamserver")
-    regex = r"^\[\*\] Team Server Version: (?P<version>\d+\.\d+\.\d+) \((?P<year>\d{4})(?P<month>\d{2})(?P<day>\d{2})\) (?P<licensed>.*)$"
+    regex = r"^\[\*\] Team Server Version: (?P<version>(\d+\.)?\d+) (?P<licensed>.*)$"
     # Note that re.MULTILINE is critical here, since the output of the
     # command spans several lines
     match = re.search(regex, strip_ansi(cmd.stdout), re.MULTILINE)
@@ -52,13 +50,6 @@ def test_version_and_license(host):
     assert (
         semver.VersionInfo.parse(version) >= min_expected_version
     ), f"Cobalt Strike version is expected to be greater than or equal to {min_expected_version}."
-
-    year = int(match.group("year"))
-    month = int(match.group("month"))
-    day = int(match.group("day"))
-    assert (
-        datetime.date(year, month, day) >= min_expected_release_date
-    ), f"Cobalt Strike release date is expected to be no earlier than {min_expected_release_date}."
 
     licensed = match.group("licensed")
     assert licensed == expected_licensed_value, "Cobalt Strike is not licensed."


### PR DESCRIPTION
## 🗣 Description ##

This pull request fixes a broken Molecule test that [recently started causing APB failures](https://github.com/cisagov/ansible-role-cobalt-strike/actions/runs/4367639250).

## 💭 Motivation and context ##

The test is now broken because:
- CobaltStrike changed the version text that is output as of the most recent release (4.8).
- CobaltStrike does not strictly adhere to the semver standard.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.