### PR TITLE
Use ansible.builtin.uri to get download token

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,7 +40,7 @@
       ansible.builtin.get_url:
         url: "https://download.cobaltstrike.com/downloads/{{ cobaltstrike_token_content }}/cobaltstrike-dist.tgz"
         dest: /tmp
-        mode: '0644'
+        mode: "0644"
 
     - name: Extract the Cobalt Strike tarball
       ansible.builtin.unarchive:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,7 +35,7 @@
 
     - name: Set CobaltStrike token fact
       ansible.builtin.set_fact:
-        cobaltstrike_token_content: "{{ cobaltstrike_token.content | regex_findall('href=\"/downloads/([^/]*)/', multiline=true) | first }}"
+        cobaltstrike_token_content: "{{ cobaltstrike_token.content | regex_search('href=\"/downloads/(.+)/cobaltstrike-dist.zip\"', '\\1') | first }}"
 
     - name: Extract the download token and download the Cobalt Strike tarball
       ansible.builtin.get_url:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,19 +11,19 @@
     - name: Grab Cobalt Strike license from S3
       amazon.aws.aws_s3:
         bucket: "{{ cobalt_strike_bucket_name }}"
-        object: "{{ cobalt_strike_license_object_name }}"
         dest: /tmp/cobaltstrike.license
         mode: get
+        object: "{{ cobalt_strike_license_object_name }}"
       become: false
       delegate_to: localhost
 
     - name: Get CobaltStrike download token
       ansible.builtin.uri:
-        url: https://download.cobaltstrike.com/download
-        method: POST
         body: dlkey={{ cobaltstrike_license }}
         body_format: form-urlencoded
+        method: POST
         return_content: true
+        url: https://download.cobaltstrike.com/download
       delegate_to: localhost
       register: cobaltstrike_token
       # The file /tmp/cobaltstrike.license doesn't exist until
@@ -39,15 +39,15 @@
 
     - name: Extract the download token and download the Cobalt Strike tarball
       ansible.builtin.get_url:
-        url: "https://download.cobaltstrike.com/downloads/{{ cobaltstrike_token_content }}/cobaltstrike-dist.tgz"
         dest: /tmp
         mode: "0644"
+        url: "https://download.cobaltstrike.com/downloads/{{ cobaltstrike_token_content }}/cobaltstrike-dist.tgz"
 
     - name: Extract the Cobalt Strike tarball
       ansible.builtin.unarchive:
-        src: /tmp/cobaltstrike-dist.tgz
         dest: /opt
         remote_src: true
+        src: /tmp/cobaltstrike-dist.tgz
 
     - name: Delete remote copy of Cobalt Strike tarball
       ansible.builtin.file:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,7 +17,7 @@
       become: false
       delegate_to: localhost
 
-    - name: Get CobaltStrike Download Token
+    - name: Get CobaltStrike download token
       ansible.builtin.uri:
         url: https://download.cobaltstrike.com/download
         method: POST
@@ -32,7 +32,7 @@
         cobaltstrike_license: >-
           "{{ lookup('file', '/tmp/cobaltstrike.license') }}"
 
-    - name: Set CobaltStrike Token Fact
+    - name: Set CobaltStrike token fact
       ansible.builtin.set_fact:
         cobaltstrike_token_content: "{{ cobaltstrike_token.content | regex_findall('href=\"/downloads/([^/]*)/', multiline=true) | first }}"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,6 +22,7 @@
         url: https://download.cobaltstrike.com/download
         method: POST
         body: dlkey={{ cobaltstrike_license }}
+        body_format: form-urlencoded
         return_content: true
       delegate_to: localhost
       register: cobaltstrike_token

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,44 +17,24 @@
       become: no
       delegate_to: localhost
 
-    - name: Install curl
-      ansible.builtin.package:
-        name:
-          - curl
-
-    # I'd prefer to use ansible.builtin.uri here, but the following
-    # code doesn't work with the Cobalt Strike site:
-    # - name: Get download token from Cobalt Strike website
-    #   ansible.builtin.uri:
-    #     body: dlkey={{ cobaltstrike_license }}
-    #     body_format: "form-urlencoded"
-    #     dest: /tmp/html.html
-    #     method: POST
-    #     return_content: yes
-    #     url: https://www.cobaltstrike.com/download
-    #   become: no
-    #   delegate_to: localhost
-    #   register: download_token
-    #   vars:
-    #     cobaltstrike_license: >-
-    #       "{{ lookup('file', '/tmp/cobaltstrike.license') }}"
-    #
-    # This is the reason for the skip_ansible_lint tag below.
-    - name: Get download token from Cobalt Strike website
-      ansible.builtin.command: >-
-        curl https://download.cobaltstrike.com/download
-        --data "dlkey={{ cobaltstrike_license }}" --output /tmp/token.html
-      become: no
-      delegate_to: localhost
-      tags:
-        - skip_ansible_lint
+    - name: Get CobaltStrike Download Token
+      ansible.builtin.uri:
+        url: https://download.cobaltstrike.com/download
+        method: POST
+        body: "dlkey={{ cobaltstrike_license }}"
+        return_content: true
+      register: cobaltstrike_token
       vars:
         cobaltstrike_license: >-
           "{{ lookup('file', '/tmp/cobaltstrike.license') }}"
 
+    - name: Set CobaltStrike Token Fact
+      ansible.builtin.set_fact:
+        cobaltstrike_token_content: "{{ cobaltstrike_token.content | regex_findall('href=\"/downloads/([^/]*)/', multiline=true) | first }}"
+
     - name: Extract the download token and download the Cobalt Strike tarball
       ansible.builtin.get_url:
-        url: "https://download.cobaltstrike.com/downloads/{{ lookup('file', '/tmp/token.html') | regex_search('href=\"/downloads/(.+)/cobaltstrike-dist.zip\"', '\\1') | first }}/cobaltstrike-dist.tgz"
+        url: "https://download.cobaltstrike.com/downloads/{{ cobaltstrike_token_content }}/cobaltstrike-dist.tgz"
         dest: /tmp
         mode: '0644'
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,7 +12,7 @@
       amazon.aws.aws_s3:
         bucket: "{{ cobalt_strike_bucket_name }}"
         object: "{{ cobalt_strike_license_object_name }}"
-        dest: "/tmp/cobaltstrike.license"
+        dest: /tmp/cobaltstrike.license
         mode: get
       become: no
       delegate_to: localhost
@@ -21,7 +21,7 @@
       ansible.builtin.uri:
         url: https://download.cobaltstrike.com/download
         method: POST
-        body: "dlkey={{ cobaltstrike_license }}"
+        body: dlkey={{ cobaltstrike_license }}
         return_content: true
       register: cobaltstrike_token
       vars:
@@ -138,7 +138,7 @@
 
     - name: Delete local copies of Cobalt Strike license and download token
       ansible.builtin.file:
-        path: "/tmp/{{ item }}"
+        path: /tmp/{{ item }}
         state: absent
       become: no
       delegate_to: localhost

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,6 +23,7 @@
         method: POST
         body: dlkey={{ cobaltstrike_license }}
         return_content: true
+      delegate_to: localhost
       register: cobaltstrike_token
       vars:
         cobaltstrike_license: >-

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,7 +25,10 @@
         return_content: true
       delegate_to: localhost
       register: cobaltstrike_token
-      vars:
+      # The file /tmp/cobaltstrike.license doesn't exist until
+      # it is downloaded so the linter fails the lookup, which
+      # is the reason for the noqa below
+      vars: # noqa jinja[invalid]
         cobaltstrike_license: >-
           "{{ lookup('file', '/tmp/cobaltstrike.license') }}"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,7 +14,7 @@
         object: "{{ cobalt_strike_license_object_name }}"
         dest: /tmp/cobaltstrike.license
         mode: get
-      become: no
+      become: false
       delegate_to: localhost
 
     - name: Get CobaltStrike Download Token
@@ -46,7 +46,7 @@
       ansible.builtin.unarchive:
         src: /tmp/cobaltstrike-dist.tgz
         dest: /opt
-        remote_src: yes
+        remote_src: true
 
     - name: Delete remote copy of Cobalt Strike tarball
       ansible.builtin.file:
@@ -144,7 +144,7 @@
       ansible.builtin.file:
         path: /tmp/{{ item }}
         state: absent
-      become: no
+      become: false
       delegate_to: localhost
       loop:
         - cobaltstrike.license

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,7 +31,7 @@
       # is the reason for the noqa below
       vars: # noqa jinja[invalid]
         cobaltstrike_license: >-
-          "{{ lookup('file', '/tmp/cobaltstrike.license') }}"
+          {{ lookup("file", "/tmp/cobaltstrike.license") }}
 
     - name: Set CobaltStrike token fact
       ansible.builtin.set_fact:
@@ -139,7 +139,7 @@
       # is the reason for the noqa below
       vars: # noqa jinja[invalid]
         cobaltstrike_license: >-
-          "{{ lookup('file', '/tmp/cobaltstrike.license') }}"
+          {{ lookup("file", "/tmp/cobaltstrike.license") }}
 
     - name: Delete local copies of Cobalt Strike license and download token
       ansible.builtin.file:


### PR DESCRIPTION
Use ansible.builtin.uri to get download token

## 🗣 Description ##

Switches from using `curl` to get CS download token to using the `ansible.builtin.uri` module. 

## 💭 Motivation and context ##

Simplicity and uses native ansible functionality with no dependency on external tools (`curl`) 

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.