### PR TITLE
Use the new name `amazon.aws.s3_object`

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,7 +9,7 @@
   when: not cobaltstrike_auth.stat.exists
   block:
     - name: Grab Cobalt Strike license from S3
-      amazon.aws.aws_s3:
+      amazon.aws.s3_object:
         bucket: "{{ cobalt_strike_bucket_name }}"
         dest: /tmp/cobaltstrike.license
         mode: get


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the role to use the new name `amazon.aws.s3_object` instead of the old, deprecated name `amazon.aws.aws_s3`.

## 💭 Motivation and context ##

The old name `amazon.aws.aws_s3` is still accepted but not preferred.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.