### PR TITLE
Adapt to new Cobalt Strike download names, executables, and install locations

### DIFF
--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -39,7 +39,7 @@ def test_files2(host, f):
 
 def test_version_and_license(host):
     """Verify that Cobalt Strike is licensed and is an expected version."""
-    cmd = host.run("cd /opt/cobaltstrike && ./teamserver")
+    cmd = host.run("cd /opt/cobaltstrike/server && ./teamserver")
     regex = (
         r"^\[\*\] Team Server Version: (?P<version>(\d+)(\.\d+){1,2}) (?P<licensed>.*)$"
     )

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -22,7 +22,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     "f",
     [
         "/opt/cobaltstrike",
-        "/opt/cobaltstrike/cobaltstrike.auth",
+        "/opt/cobaltstrike/client/cobaltstrike.auth.client",
         "/opt/cobaltstrike/update",
     ],
 )

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -10,7 +10,7 @@ import semver
 from strip_ansi import strip_ansi
 import testinfra.utils.ansible_runner
 
-min_expected_version = semver.VersionInfo.parse("4.8.0")
+min_expected_version = semver.VersionInfo.parse("4.10.0")
 expected_licensed_value = "Licensed"
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,7 @@
 # Check if Cobalt Strike is already installed in the expected place
 - name: Check if Cobalt Strike is already installed and licensed
   ansible.builtin.stat:
-    path: /opt/cobaltstrike/cobaltstrike.auth
+    path: /opt/cobaltstrike/client/cobaltstrike.auth.client
   register: cobaltstrike_auth
 
 - name: Install and license Cobalt Strike
@@ -128,7 +128,7 @@
         }
       args:
         chdir: /opt/cobaltstrike
-        creates: /opt/cobaltstrike/cobaltstrike.auth
+        creates: /opt/cobaltstrike/client/cobaltstrike.auth.client
         executable: /usr/bin/expect
       failed_when: expect.rc != 0
       # The CS license key is sensitive

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,23 +35,23 @@
 
     - name: Set CobaltStrike token fact
       ansible.builtin.set_fact:
-        cobaltstrike_token_content: "{{ cobaltstrike_token.content | regex_search('href=\"/downloads/(.+)/cobaltstrike-dist.zip\"', '\\1') | first }}"
+        cobaltstrike_token_content: "{{ cobaltstrike_token.content | regex_search('href=\"/downloads/(.+)/cobaltstrike-dist-windows.zip\"', '\\1') | first }}"
 
     - name: Extract the download token and download the Cobalt Strike tarball
       ansible.builtin.get_url:
         dest: /tmp
         mode: "0644"
-        url: "https://download.cobaltstrike.com/downloads/{{ cobaltstrike_token_content }}/cobaltstrike-dist.tgz"
+        url: "https://download.cobaltstrike.com/downloads/{{ cobaltstrike_token_content }}/cobaltstrike-dist-linux.tgz"
 
     - name: Extract the Cobalt Strike tarball
       ansible.builtin.unarchive:
         dest: /opt
         remote_src: true
-        src: /tmp/cobaltstrike-dist.tgz
+        src: /tmp/cobaltstrike-dist-linux.tgz
 
     - name: Delete remote copy of Cobalt Strike tarball
       ansible.builtin.file:
-        path: /tmp/cobaltstrike-dist.tgz
+        path: /tmp/cobaltstrike-dist-linux.tgz
         state: absent
 
     #


### PR DESCRIPTION
## 🗣 Description ##

This pull request updates the Ansible role to handle recent changes to:
- The names of Cobalt Strike archives downloaded from the Cobalt Strike web page
- The new location of the Cobalt Strike auth (i.e. licensing) file
- The new location of the Cobalt Strike `teamserver` executable

## 💭 Motivation and context ##

The role was failing as it was, so these changes are necessary.  See [this build](https://github.com/cisagov/teamserver-packer/actions/runs/10391496986), for example.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.