### PR TITLE
Move `amazon.aws` and `boto3` requirements to `Requirements` section

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,9 @@ in the repository's settings.
 
 ## Requirements ##
 
-None.
+- Requires the `amazon.aws` collection and the `boto3` Python package
+  to be present on the Ansible controller since the role code uses
+  `amazon.aws.s3_object`, delegated to `localhost`.
 
 ## Role Variables ##
 
@@ -114,9 +116,6 @@ None.
 ## Dependencies ##
 
 - [cisagov/ansible-role-openjdk](https://github.com/cisagov/ansible-role-openjdk)
-- Depends on the `amazon.aws` collection and the `boto3` Python
-  package being present on the Ansible controller since the role code
-  uses `amazon.aws.s3_object`, delegated to `localhost`.
 
 ## Installation ##
 


### PR DESCRIPTION
## 🗣 Description ##

This pull request moves the `amazon.aws` and `boto3` requirements to the `Requirements` section.

## 💭 Motivation and context ##

This is a better place for these requirements that are not tracked by Ansible.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.